### PR TITLE
fix requirements utils

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 requests
 chardet
+utils
 web.py
 sqlalchemy
 


### PR DESCRIPTION
解决pip安装webpy时 出现No module named 'utils'的问题
在requirments.txt中加入utils