### PR TITLE
The working process in validator still exists in the system when they are not necessary

### DIFF
--- a/validator/Validator.py
+++ b/validator/Validator.py
@@ -7,7 +7,7 @@ import os
 import gevent
 import requests
 import time
-
+import psutil
 from multiprocessing import Process, Queue
 
 import config


### PR DESCRIPTION
This change will kill the process after they are popped out of the queue based on 'psutil' from third-party library.