### PR TITLE
在使用pymongo数据库情况下，接口有count查询字段时返回list为空的bug修复

### DIFF
--- a/db/MongoHelper.py
+++ b/db/MongoHelper.py
@@ -44,6 +44,8 @@ class MongoHelper(ISqlHelper):
             count = 0
         if conditions:
             conditions = dict(conditions)
+            if 'count' in conditions:
+                del conditions['count']
             conditions_name = ['types', 'protocol']
             for condition_name in conditions_name:
                 value = conditions.get(condition_name, None)


### PR DESCRIPTION
在MongoHelper.py中的select方法中作为参数传入的conditions字典中的count属性需要移除，否则在mongodb中查找时多了一个不存在的查询字段，返回的list既为空。
`
            if 'count' in conditions:
                del conditions['count']
`